### PR TITLE
add runtime config for redacting bytes

### DIFF
--- a/protobuf/src/atomic_flags.rs
+++ b/protobuf/src/atomic_flags.rs
@@ -1,7 +1,12 @@
 //! Library to configure runtime configurations
 
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 
 /// If `REDACT_BYTES` is set, all bytes and strings will be
-/// formatted as "???"
-pub static REDACT_BYTES: AtomicBool = AtomicBool::new(false);
+/// formatted as "?"
+pub(crate) static REDACT_BYTES: AtomicBool = AtomicBool::new(false);
+
+pub fn set_redact_bytes(redact_bytes: bool) {
+    REDACT_BYTES.store(redact_bytes, Ordering::Relaxed);
+}

--- a/protobuf/src/atomic_flags.rs
+++ b/protobuf/src/atomic_flags.rs
@@ -1,0 +1,7 @@
+//! Library to configure runtime configurations
+
+use std::sync::atomic::AtomicBool;
+
+/// If `REDACT_BYTES` is set, all bytes and strings will be
+/// formatted as "???"
+pub static REDACT_BYTES: AtomicBool = AtomicBool::new(false);

--- a/protobuf/src/core.rs
+++ b/protobuf/src/core.rs
@@ -491,6 +491,7 @@ macro_rules! debug_to_pb_print {
 mod test {
 
     use super::*;
+    use crate::atomic_flags::set_redact_bytes;
 
     #[test]
     fn test_redact_bytes() {
@@ -507,11 +508,11 @@ mod test {
         // tests to fail. You may run this test manually
         // to verify the result.
 
-        REDACT_BYTES.store(true, Ordering::Relaxed);
+        set_redact_bytes(true);
         let mut buf = String::new();
         let src_str = b"23332333".to_vec();
         PbPrint::fmt(&src_str, "test", &mut buf);
         assert_eq!(buf, "test: ?");
-        REDACT_BYTES.store(false, Ordering::Relaxed);
+        set_redact_bytes(false);
     }
 }

--- a/protobuf/src/core.rs
+++ b/protobuf/src/core.rs
@@ -492,3 +492,32 @@ macro_rules! debug_to_pb_print {
         }
     };
 }
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_redact_bytes() {
+        let mut buf = String::new();
+        redact_bytes(10, &mut buf);
+        assert_eq!(buf, "??????????");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_redact_PbPrint() {
+        // This test is intentionally ignored because
+        // changing `REDACT_BYTES` globally may cause other
+        // tests to fail. You may run this test manually
+        // to verify the result.
+
+        REDACT_BYTES.store(true, Ordering::Relaxed);
+        let mut buf = String::new();
+        let src_str = b"23332333".to_vec();
+        PbPrint::fmt(&src_str, "test", &mut buf);
+        assert_eq!(buf, "test: ????????");
+        REDACT_BYTES.store(false, Ordering::Relaxed);
+    }
+}

--- a/protobuf/src/lib.rs
+++ b/protobuf/src/lib.rs
@@ -90,7 +90,7 @@ pub mod atomic_flags;
 
 // so `use protobuf::*` could work in mod descriptor and well_known_types
 mod protobuf {
-    pub use atomic_flags::REDACT_BYTES;
+    pub use atomic_flags::set_redact_bytes;
     pub use cached_size::CachedSize;
     pub use clear::Clear;
     pub use core::*;

--- a/protobuf/src/lib.rs
+++ b/protobuf/src/lib.rs
@@ -85,8 +85,12 @@ mod misc;
 
 mod buf_read_iter;
 
+// used to change runtime configs
+pub mod atomic_flags;
+
 // so `use protobuf::*` could work in mod descriptor and well_known_types
 mod protobuf {
+    pub use atomic_flags::REDACT_BYTES;
     pub use cached_size::CachedSize;
     pub use clear::Clear;
     pub use core::*;


### PR DESCRIPTION
In this PR, we export a `REDACT_BYTES` atomic bool globally from `protobuf` crate. This way, we could redact user data in log without changing too much in TiKV.

After this PR gets merged, we'll continue working on https://github.com/tikv/tikv/pull/8670 to complete the redact log feature.

There's still some room for improvement for this feature, which might be worked on later.

* configure `REDACT_BYTES` as a crate feature
* use some kind of extra info to indicate if we should redact a field, as suggested by @yiwu-arbug 
```
message Region {
    uint64 id = 1;
    bytes start_key = 2 [need_redact = true];
    bytes end_key = 3 [need_redact = true];
}
```