### PR TITLE
less allocate and memcpy in serialization 

### DIFF
--- a/protobuf/src/core.rs
+++ b/protobuf/src/core.rs
@@ -102,7 +102,6 @@ pub trait Message: fmt::Debug + Clear + Any + Send + Sync {
 
     /// Write the message to the writer.
     fn write_to_writer_without_buffer(&self, w: &mut Write) -> ProtobufResult<()> {
-        // TODO: add a unbuffer version.
         w.with_coded_output_stream(|os| {
             os.use_internal_buffer = false;
             self.write_to(os)
@@ -113,7 +112,7 @@ pub trait Message: fmt::Debug + Clear + Any + Send + Sync {
     fn write_to_vec(&self, v: &mut Vec<u8>) -> ProtobufResult<()> {
         let size = self.compute_size() as usize;
         if v.capacity() - v.len() < size {
-            v.reserve(size - v.len());
+            v.reserve(size);
         }
         v.with_coded_output_stream(|os| self.write_to(os))
     }

--- a/protobuf/src/core.rs
+++ b/protobuf/src/core.rs
@@ -95,9 +95,18 @@ pub trait Message: fmt::Debug + Clear + Any + Send + Sync {
         }
     }
 
-    /// Write the message to the writer.
+    /// Write the message to the writer; an internal buffer is used.
     fn write_to_writer(&self, w: &mut Write) -> ProtobufResult<()> {
         w.with_coded_output_stream(|os| self.write_to(os))
+    }
+
+    /// Write the message to the writer.
+    fn write_to_writer_without_buffer(&self, w: &mut Write) -> ProtobufResult<()> {
+        // TODO: add a unbuffer version.
+        w.with_coded_output_stream(|os| {
+            os.use_internal_buffer = false;
+            self.write_to(os)
+        })
     }
 
     /// Write the message to bytes vec.


### PR DESCRIPTION
By default there is an internal buffer in `CodedOutputStream`, which is always used when serializing a `Message`. It's useful when the output stream is a disk file or pipe. However if the output is an another memory buffer, redundant `memcpy` calls are involved.
This PR add a new method `write_to_writer_without_buffer`, which can avoid such buffer mechanism. 