### PR TITLE
serialize: don't panic on short buffer

### DIFF
--- a/protobuf-test/src/common/v2/test_basic.rs
+++ b/protobuf-test/src/common/v2/test_basic.rs
@@ -298,3 +298,14 @@ fn test_parse_length_delimited_from_network_smoke() {
     let test1: Test1 = parse_length_delimited_from_reader(&mut tcp_stream).expect("parse...");
     assert_eq!(10, test1.get_a());
 }
+
+/// Test if providing a smaller buffer, protobuf can detect and report error.
+#[test]
+fn test_serialize_too_large_message() {
+    let mut test1 = Test1::new();
+    test1.set_a(150);
+    let len = test1.compute_size();
+    let mut bytes = vec![0; len as usize - 1];
+    let mut s = CodedOutputStream::bytes(&mut bytes);
+    test1.write_to_with_cached_sizes(&mut s).unwrap_err();
+}

--- a/protobuf/src/stream.rs
+++ b/protobuf/src/stream.rs
@@ -1036,7 +1036,10 @@ impl<'a> CodedOutputStream<'a> {
                 self.position = 0;
             },
             OutputTarget::Bytes => {
-                panic!("refresh_buffer must not be called on CodedOutputStream create from slice");
+                return Err(ProtobufError::IoError(io::Error::new(
+                    io::ErrorKind::Other,
+                    "given slice is too small to serialize the message",
+                )));
             }
         }
         Ok(())


### PR DESCRIPTION
This is an attempt to fix https://github.com/tikv/tikv/issues/9012.

PR to upstream: https://github.com/stepancheg/rust-protobuf/pull/571.