### PR TITLE
fix clippy warning for ProtobufValueRef

### DIFF
--- a/protobuf-codegen/src/enums.rs
+++ b/protobuf-codegen/src/enums.rs
@@ -249,7 +249,7 @@ impl<'a> EnumGen<'a> {
     fn write_impl_value(&self, w: &mut CodeWriter) {
         w.impl_for_block("::protobuf::reflect::ProtobufValue", &self.type_name, |w| {
             w.def_fn(
-                "as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef",
+                "as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_>",
                 |w| w.write_line("::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())"),
             )
         })

--- a/protobuf-codegen/src/message.rs
+++ b/protobuf-codegen/src/message.rs
@@ -400,7 +400,7 @@ impl<'a> MessageGen<'a> {
     fn write_impl_value(&self, w: &mut CodeWriter) {
         w.impl_for_block("::protobuf::reflect::ProtobufValue", &self.type_name, |w| {
             w.def_fn(
-                "as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef",
+                "as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_>",
                 |w| w.write_line("::protobuf::reflect::ProtobufValueRef::Message(self)"),
             )
         })


### PR DESCRIPTION
An example of the clippy warning:
```
error: hiding a lifetime that's elided elsewhere is confusing
   --> /home/runner/work/kvproto/kvproto/target/debug/build/kvproto-5c1efc5c4a916e49/out/protos/recoverdatapb.rs:179:15
    |
179 |     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
    |               ^^^^^     ------------------------------------- the same lifetime is hidden here
    |               |
    |               the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: use `'_` for type paths
    |
179 |     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
    |                    
```

See: https://github.com/pingcap/kvproto/actions/runs/17235386913/job/48900501951?pr=1342 for more details