### PR TITLE
Fix clippy 

### DIFF
--- a/protobuf-codegen/src/message.rs
+++ b/protobuf-codegen/src/message.rs
@@ -359,14 +359,14 @@ impl<'a> MessageGen<'a> {
             w.write_line("");
             self.write_unknown_fields(w);
             w.write_line("");
-            w.def_fn("as_any(&self) -> &dyn (::std::any::Any)", |w| {
-                w.write_line("self as &dyn (::std::any::Any)");
+            w.def_fn("as_any(&self) -> &dyn ::std::any::Any", |w| {
+                w.write_line("self as &dyn ::std::any::Any");
             });
-            w.def_fn("as_any_mut(&mut self) -> &mut dyn (::std::any::Any)", |w| {
-                w.write_line("self as &mut dyn (::std::any::Any)");
+            w.def_fn("as_any_mut(&mut self) -> &mut dyn ::std::any::Any", |w| {
+                w.write_line("self as &mut dyn ::std::any::Any");
             });
             w.def_fn(
-                "into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)>",
+                "into_any(self: Box<Self>) -> ::std::boxed::Box<dyn ::std::any::Any>",
                 |w| {
                     w.write_line("self");
                 },


### PR DESCRIPTION
```
error: unnecessary parentheses around type
   --> /home/runner/work/kvproto/kvproto/target/debug/build/kvproto-a91e8e76886de18f/out/protos/replication_modepb.rs:168:30
    |
168 |     fn as_any(&self) -> &dyn (::std::any::Any) {
    |                              ^               ^
    |
    = note: `-D unused-parens` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_parens)]`
help: remove these parentheses
    |
168 -     fn as_any(&self) -> &dyn (::std::any::Any) {
168 +     fn as_any(&self) -> &dyn ::std::any::Any {
    |
```