### PR TITLE
protobuf: sort UnknownFields before writing for reproducible encoding

### DIFF
--- a/protobuf/src/stream.rs
+++ b/protobuf/src/stream.rs
@@ -1363,7 +1363,17 @@ impl<'a> CodedOutputStream<'a> {
 
     /// Write unknown fields
     pub fn write_unknown_fields(&mut self, fields: &UnknownFields) -> ProtobufResult<()> {
-        for (number, values) in fields {
+        // `UnknownFields` is backed by a `HashMap`, whose iteration
+        // order is hash-randomized. Sort by field number before writing
+        // so the encoded bytes are stable across runs — required for
+        // reproducible builds when the encoded `FileDescriptorProto` is
+        // embedded as a `static &[u8]` (e.g. by `protobuf-codegen`'s
+        // `file.write_to_bytes()`), and a sensible default in any case.
+        // Encoded size is order-independent, so `unknown_fields_size`
+        // does not need the same treatment.
+        let mut sorted: Vec<_> = fields.iter().collect();
+        sorted.sort_by_key(|&(n, _)| n);
+        for (number, values) in sorted {
             for value in values {
                 self.write_unknown(number, value)?;
             }


### PR DESCRIPTION
`UnknownFields` stores its entries in a `HashMap<u32, UnknownValues>`, and `CodedOutputStream::write_unknown_fields` iterates that map directly, so the order of encoded extension/unknown fields is hash-randomized and varies between processes (and across builds when this encoder is invoked at build time).

This shows up as a reproducibility hazard for any consumer that embeds a re-serialized `FileDescriptorProto` as a `static &[u8]`. In TiKV's case, `protobuf-codegen` calls `file.write_to_bytes()` while generating `tipb`'s Rust source; tipb's .proto files declare several gogoproto and rustproto `option (...) = ...` extensions which the parser does not know and therefore stashes in `UnknownFields`. The re-serialized bytes for those extensions then land in `.rodata` in a non-deterministic permutation, breaking byte-for-byte reproduction of `tikv-server`.

Sort by field number at the write site only. This is the minimal change that fixes the user-visible non-determinism without altering any public type (the `HashMap` storage and the `UnknownFieldsIter` type stay as they are). `unknown_fields_size` does not need a matching change because the encoded size is order-independent.